### PR TITLE
java api wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,10 @@ repositories {
 dependencies {
 
     //Logger
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 
-    compile group: 'org.json',             name: 'json',   version: '20180130'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
-    compile group: 'com.google.code.gson', name: 'gson',   version: '2.8.5'
+    compile group: 'org.json',             name: 'json',   version: '20220320'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
+    compile group: 'com.google.code.gson', name: 'gson',   version: '2.9.0'
     compile group: 'com.fatboyindustrial.gson-javatime-serialisers', name: 'gson-javatime-serialisers', version: '1.1.1'
 }


### PR DESCRIPTION
Recently people in topgg-api channel have been saying that the java api has been giving them 401 errors, and the last time this has been touched was 3 years ago


From what I am able to tell about the cause of the error is that the base API domain was changed in the code, however, that change in the code was never released on jitpack, so people are getting errors because the package was never updated to reflect the changes made in the code on github. 

I have spoken to nik (the previous java library maintainer) and they have said that it's okay for me to take it off their hands

I have updated the dependencies in this PR because they were very outdated. 

![DiscordDevelopment_PffbzS9807](https://user-images.githubusercontent.com/49874713/159997405-ba14382b-ea1d-4d90-b3af-167687cda882.png)
s