### PR TITLE
Maven fixes for jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 group 'org.discordbots'
 
 apply plugin: 'java'
+apply plugin: 'maven'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Added fix to comply with Jitpacks documentation.
https://docs.jitpack.io/building/#gradle-projects

This should fix installation issues for maven users.