### PR TITLE
Update download section with up-to-date dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ api.getVotingMultiplier().whenComplete((multiplier, e) -> {
 
 ## Download
 
-[![Release](https://jitpack.io/v/DiscordBotList/DBL-Java-Library.svg)](https://jitpack.io/#DiscordBotList/DBL-Java-Library)
+[![Release](https://jitpack.io/v/top-gg/java-sdk.svg)](https://jitpack.io/#top-gg/java-sdk)
 
 Replace `VERSION` with the latest version or commit hash. The latest version can be found under releases.
 
@@ -84,8 +84,8 @@ Replace `VERSION` with the latest version or commit hash. The latest version can
 ```xml
 <dependencies>
     <dependency>
-        <groupId>org.discordbots</groupId>
-        <artifactId>DBL-Java-Library</artifactId>
+        <groupId>com.github.top-gg</groupId>
+        <artifactId>java-sdk</artifactId>
         <version>VERSION</version>
     </dependency>
 </dependencies>
@@ -99,7 +99,7 @@ repositories {
 ```
 ```gradle
 dependencies {
-    compile 'org.discordbots:DBL-Java-Library:VERSION'
+    compile 'com.github.top-gg:java-sdk:VERSION'
 }
 ```
 


### PR DESCRIPTION
After the repo rename, the download section in the readme was not updated with the correct info yet.